### PR TITLE
Adding Dense Bool Arrays

### DIFF
--- a/src/mlir/ir/attribute.rs
+++ b/src/mlir/ir/attribute.rs
@@ -1,10 +1,11 @@
 mod bool;
+mod dense_bool;
 mod dense_i32;
 mod float;
 mod integer;
 mod string;
 
-pub use self::{bool::*, dense_i32::*, float::*, integer::*, string::*};
+pub use self::{bool::*, dense_bool::*, dense_i32::*, float::*, integer::*, string::*};
 use crate::{
     ir::{IdentifierRef, TypeRef},
     support::{

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -74,7 +74,6 @@ impl DenseBoolAttributeRef {
         assert!(index < self.len());
         unsafe {  mlirDenseBoolArrayGetElement(self.to_raw(), index) }
     }
-
 }
 
 #[cfg(test)]
@@ -95,4 +94,3 @@ mod tests {
         };
     }
 }
-

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 use mlir_sys::{
     mlirAttributeIsADenseBoolArray, mlirDenseArrayGetNumElements,
-    mlirDenseBoolArrayGet, mlirDenseBoolArrayGetElement, MlirAttribute
+    mlirDenseBoolArrayGetElement, mlirDenseBoolArrayGet, MlirAttribute
 };
 
 /// [DenseBoolAttributeRef] is a reference to an instance of the `mlir::DenseBoolArrayAttr`, which
@@ -54,6 +54,12 @@ impl DenseBoolAttributeRef {
     /// Returns the length of the array.
     pub fn len(&self) -> isize {
         unsafe { mlirDenseArrayGetNumElements(self.to_raw()) }
+    }
+
+    /// # Returns
+    /// Returns whether the array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Gets the element at the provided index, verifying that the index is within bounds.

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -1,17 +1,14 @@
 use super::impl_attribute_variant;
-use crate::{
-    support::binding::impl_unowned_mlir_value,
-    ContextRef, UnownedMlirValue,
-};
+use crate::{support::binding::impl_unowned_mlir_value, ContextRef, UnownedMlirValue};
 
 use std::{marker::PhantomData, os::raw::c_int};
 
 use mlir_sys::{
-    mlirAttributeIsADenseBoolArray, mlirDenseArrayGetNumElements,
-    mlirDenseBoolArrayGetElement, mlirDenseBoolArrayGet, MlirAttribute
+    mlirAttributeIsADenseBoolArray, mlirDenseArrayGetNumElements, mlirDenseBoolArrayGet,
+    mlirDenseBoolArrayGetElement, MlirAttribute,
 };
 
-/// [DenseBoolAttributeRef] is a reference to an instance of the `mlir::DenseBoolArrayAttr`, which
+/// [`DenseBoolAttributeRef`] is a reference to an instance of the `mlir::DenseBoolArrayAttr`, which
 /// represents a constant array of booleans in the MLIR IR.
 ///
 /// The following bindings into the MLIR C API are used/supported:
@@ -32,14 +29,14 @@ impl_unowned_mlir_value!(no_refs, DenseBoolAttributeRef, MlirAttribute);
 impl_attribute_variant!(DenseBoolAttributeRef, mlirAttributeIsADenseBoolArray);
 
 impl DenseBoolAttributeRef {
-    /// Constructs a new dense array of boolean attributes with the provided values.
+    /// Constructs a new dense array of booleans attribute with the provided values.
     ///
     /// # Arguments
     /// * `context` - The context that should own the attribute.
-    /// * `values` - The integers to hold in the attribute.
+    /// * `values` - The booleans to hold in the attribute.
     ///
     /// # Returns
-    /// Returns a reference to a new [DenseBoolAttributeRef] instance.
+    /// Returns a reference to a new [`DenseBoolAttributeRef`] instance.
     pub fn new<'a>(context: &'a ContextRef, values: &[bool]) -> &'a Self {
         let int_values: Vec<c_int> = values.iter().map(|&b| if b { 1 } else { 0 }).collect();
         unsafe {
@@ -72,7 +69,7 @@ impl DenseBoolAttributeRef {
     /// Returns the boolean at the provided index.
     pub fn get(&self, index: isize) -> bool {
         assert!(index < self.len());
-        unsafe {  mlirDenseBoolArrayGetElement(self.to_raw(), index) }
+        unsafe { mlirDenseBoolArrayGetElement(self.to_raw(), index) }
     }
 }
 
@@ -84,13 +81,11 @@ mod tests {
     #[test]
     fn test_dense_bool_attribute() {
         let context = Context::new(None, false);
-        {
-            let values = [true, false, true];
-            let attr = DenseBoolAttributeRef::new(&context, &values);
-            assert_eq!(attr.len(), 3);
-            assert_eq!(attr.get(0), true);
-            assert_eq!(attr.get(1), false);
-            assert_eq!(attr.get(2), true);
-        };
+        let values = [true, false, true];
+        let attr = DenseBoolAttributeRef::new(&context, &values);
+        assert_eq!(attr.len(), 3);
+        assert!(attr.get(0));
+        assert!(!attr.get(1));
+        assert!(attr.get(2));
     }
 }

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -1,0 +1,72 @@
+use super::impl_attribute_variant;
+use crate::{
+    support::binding::impl_unowned_mlir_value,
+    ContextRef, UnownedMlirValue,
+};
+
+use std::marker::PhantomData;
+
+use mlir_sys::{
+    mlirAttributeIsADenseBoolArray, mlirDenseArrayGetNumElements,
+    mlirDenseBoolArrayGet, mlirDenseBoolArrayGetElement, MlirAttribute
+};
+
+/// [DenseBoolAttributeRef] is a reference to an instance of the `mlir::DenseBoolArrayAttr`, which
+/// represents a constant array of booleans in the MLIR IR.
+///
+/// The following bindings into the MLIR C API are used/supported:
+/// - `mlirAttributeIsADenseBoolArray`
+/// - `mlirDenseArrayGetNumElements`
+/// - `mlirDenseBoolArrayGetElement`
+/// - `mlirDenseBoolArrayGet`
+///
+/// The following bindings are not used/supported:
+/// - `mlirDenseArrayAttrGetTypeID`
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct DenseBoolAttributeRef {
+    _prevent_external_instantiation: PhantomData<()>,
+}
+
+impl_unowned_mlir_value!(no_refs, DenseBoolAttributeRef, MlirAttribute);
+impl_attribute_variant!(DenseBoolAttributeRef, mlirAttributeIsADenseBoolArray);
+
+impl DenseBoolAttributeRef {
+    /// Constructs a new dense array of boolean attributes with the provided values.
+    ///
+    /// # Arguments
+    /// * `context` - The context that should own the attribute.
+    /// * `values` - The integers to hold in the attribute.
+    ///
+    /// # Returns
+    /// Returns a reference to a new [DenseBoolAttributeRef] instance.
+    pub fn new<'a>(context: &'a ContextRef, values: &[i32]) -> &'a Self {
+        unsafe {
+            Self::from_raw(mlirDenseBoolArrayGet(
+                context.to_raw(),
+                values.len() as isize,
+                values.as_ptr(),
+            ))
+        }
+    }
+
+    /// # Returns
+    /// Returns the length of the array.
+    pub fn len(&self) -> isize {
+        unsafe { mlirDenseArrayGetNumElements(self.to_raw()) }
+    }
+
+    /// Gets the element at the provided index, verifying that the index is within bounds.
+    ///
+    /// # Arguments
+    /// * `index` - The index of the element to get.
+    ///
+    /// # Returns
+    /// Returns the boolean at the provided index.
+    pub fn get(&self, index: isize) -> bool {
+        assert!(index < self.len());
+        unsafe {  mlirDenseBoolArrayGetElement(self.to_raw(), index) }
+    }
+
+}
+


### PR DESCRIPTION
This is needed to support lists of booleans as an attribute for operations.