### PR TITLE
[DRAFT] Adding PassManagers

### DIFF
--- a/src/mlir.rs
+++ b/src/mlir.rs
@@ -3,6 +3,8 @@ mod dialect;
 mod dialect_handle;
 mod dialect_registry;
 pub mod ir;
+pub mod pass;
 mod string_ref;
+mod logical_result;
 
-pub use self::{context::*, dialect::*, dialect_handle::*, dialect_registry::*, string_ref::*};
+pub use self::{context::*, dialect::*, dialect_handle::*, dialect_registry::*, logical_result::*, string_ref::*};

--- a/src/mlir/ir/operation.rs
+++ b/src/mlir/ir/operation.rs
@@ -121,6 +121,8 @@ impl<'c> Operation<'c> {
         let source = CString::new(source).expect("Failed to convert source string to CString");
         let source_ref = StringRef::from_cstring(&source).to_raw();
         let source_filename_ref = StringRef::from(&source_filename).to_raw();
+        println!("source_ref: {:?}", source_ref);
+        println!("source_filename_ref: {:?}", source_filename_ref);
         unsafe {
             Self::try_from_raw(mlirOperationCreateParse(
                 context.to_raw(),

--- a/src/mlir/ir/operation.rs
+++ b/src/mlir/ir/operation.rs
@@ -121,8 +121,6 @@ impl<'c> Operation<'c> {
         let source = CString::new(source).expect("Failed to convert source string to CString");
         let source_ref = StringRef::from_cstring(&source).to_raw();
         let source_filename_ref = StringRef::from(&source_filename).to_raw();
-        println!("source_ref: {:?}", source_ref);
-        println!("source_filename_ref: {:?}", source_filename_ref);
         unsafe {
             Self::try_from_raw(mlirOperationCreateParse(
                 context.to_raw(),

--- a/src/mlir/logical_result.rs
+++ b/src/mlir/logical_result.rs
@@ -1,0 +1,56 @@
+use mlir_sys::MlirLogicalResult;
+
+/// A LogicalResult is a wrapper around MlirLogicalResult.
+/// MlirLogicalResult is a type used to represent the result of a logical operation.
+pub struct LogicalResult {
+    raw: MlirLogicalResult,
+}
+
+impl LogicalResult {
+
+    /// Creates a success result.
+    pub const fn success() -> Self {
+        Self {
+            raw: MlirLogicalResult { value: 1 },
+        }
+    }
+
+    /// Creates a failure result.
+    pub const fn failure() -> Self {
+        Self {
+            raw: MlirLogicalResult { value: 0 },
+        }
+    }
+
+    /// Checks to see if the logical result is a success.
+    pub fn succeeded(&self) -> bool {
+        self.raw.value != 0
+    }
+
+    /// Checks to see if the logical result is a failure.
+    pub fn failed(&self) -> bool {
+        self.raw.value == 0
+    }
+
+    pub fn from_raw(raw: MlirLogicalResult) -> Self {
+        Self { raw }
+    }
+}
+
+mod tests {
+    use crate::LogicalResult;
+
+    #[test]
+    fn success() {
+        let result = LogicalResult::success();
+        assert!(result.succeeded());
+        assert!(!result.failed());
+    }
+
+    #[test]
+    fn failure() {
+        let result = LogicalResult::failure();
+        assert!(!result.succeeded());
+        assert!(result.failed());
+    }
+}

--- a/src/mlir/pass.rs
+++ b/src/mlir/pass.rs
@@ -1,0 +1,26 @@
+mod pass_manager;
+mod transforms;
+
+pub use self::{pass_manager::*, transforms::*};
+
+use mlir_sys::MlirPass;
+
+/// A Pass in MLIR is a transformation or analysis that can be applied to a module.
+/// They must be added to a PassManager to be executed.
+pub struct Pass{
+    raw: MlirPass
+}
+
+impl Pass{
+    pub fn new(raw: MlirPass) -> Self {
+        Self { raw }
+    }
+
+    pub fn to_raw(&self) -> MlirPass {
+        self.raw
+    }
+
+    pub fn from_raw(raw: MlirPass) -> Self {
+        Self { raw }
+    }
+}

--- a/src/mlir/pass/pass_manager.rs
+++ b/src/mlir/pass/pass_manager.rs
@@ -1,0 +1,77 @@
+use std::marker::PhantomData;
+use mlir_sys::{MlirPassManager, mlirPassManagerAddOwnedPass, mlirPassManagerRunOnOp};
+use crate::{Context, OwnedMlirValue};
+use crate::ir::Operation;
+use crate::mlir::logical_result::LogicalResult;
+use crate::pass::Pass;
+
+/// A PassManager is the top-level entry point for managing a set of optimization passes over a module.
+/// It is responsible for scheduling and running the passes.
+pub struct PassManager {
+    raw: MlirPassManager,
+    _context: PhantomData<Context>,
+}
+
+impl PassManager{
+    /// Creates a new pass manager.
+    pub fn new(context: &Context) -> Self {
+        let raw = unsafe { mlir_sys::mlirPassManagerCreate(context.to_raw()) };
+        Self {
+            raw,
+            _context: PhantomData,
+        }
+    }
+
+    /// Destroys the pass manager.
+    pub fn destroy(&self) {
+        unsafe { mlir_sys::mlirPassManagerDestroy(self.raw) }
+    }
+
+    /// Adds a pass to the pass manager.
+    /// This pass will be applied to the module when the pass manager is run.
+    pub fn add_pass(&self, pass: Pass) {
+        unsafe { mlirPassManagerAddOwnedPass(self.raw, pass.to_raw()) }
+    }
+
+    /// Runs the passes added to the pass manager against a module
+    pub fn run(&self, op: &Operation){
+        let result = unsafe {
+            LogicalResult::from_raw(mlirPassManagerRunOnOp(self.raw, op.to_raw()))
+        };
+
+        assert!(result.succeeded(), "PassManager failed to run passes on the operation");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pass::transforms;
+    use super::*;
+
+    #[test]
+    fn create_destroy_pass_manager() {
+        let context = Context::new(None, false);
+        let pass_manager = PassManager::new(&context);
+        pass_manager.destroy();
+    }
+
+    #[test]
+    pub fn add_pass() {
+        let context = Context::new(None, false);
+        let pass_manager = PassManager::new(&context);
+        let pass = transforms::create_dce_pass();
+        pass_manager.add_pass(Pass::from_raw(pass));
+        pass_manager.destroy();
+    }
+
+    #[test]
+    pub fn run_pass() {
+        let context = Context::new(None, false);
+        let pass_manager = PassManager::new(&context);
+        let pass = transforms::create_dce_pass();
+        pass_manager.add_pass(Pass::from_raw(pass));
+        let operation = Operation::parse(&context, "", "").unwrap();
+        pass_manager.run(&operation);
+        pass_manager.destroy();
+    }
+}

--- a/src/mlir/pass/transforms.rs
+++ b/src/mlir/pass/transforms.rs
@@ -1,0 +1,5 @@
+use mlir_sys::{mlirCreateTransformsSymbolDCE, MlirPass};
+
+pub fn create_dce_pass() -> MlirPass {
+    unsafe { mlirCreateTransformsSymbolDCE() }
+}


### PR DESCRIPTION
This is required to handle code optimization in VCMIR. 

Current failure:

```
failures:

---- mlir::pass::pass_manager::tests::run_pass stdout ----
source_ref: MlirStringRef { data: 0x600001a91b30, length: 34 }
source_filename_ref: MlirStringRef { data: 0x106596a30, length: 0 }
thread 'mlir::pass::pass_manager::tests::run_pass' panicked at src/mlir/pass/pass_manager.rs:73:94:
called `Option::unwrap()` on a `None` value
```

This is because I'm not creating a valid Operation. Going to test this in the real use case we have in VCMIR. I'm going to leave this as a draft for now until I'm convinced it handles the functionality we need. 