### PR TITLE
Add DenseStringAttributeRef

### DIFF
--- a/src/mlir/ir/attribute.rs
+++ b/src/mlir/ir/attribute.rs
@@ -1,11 +1,14 @@
 mod bool;
 mod dense_bool;
 mod dense_i32;
+pub mod dense_string;
 mod float;
 mod integer;
 mod string;
 
-pub use self::{bool::*, dense_bool::*, dense_i32::*, float::*, integer::*, string::*};
+pub use self::{
+    bool::*, dense_bool::*, dense_i32::*, dense_string::*, float::*, integer::*, string::*,
+};
 use crate::{
     ir::{IdentifierRef, TypeRef},
     support::{

--- a/src/mlir/ir/attribute.rs
+++ b/src/mlir/ir/attribute.rs
@@ -1,7 +1,7 @@
 mod bool;
 mod dense_bool;
 mod dense_i32;
-pub mod dense_string;
+mod dense_string;
 mod float;
 mod integer;
 mod string;

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn no_owned_dense_bool_attribute_ref() {
-        let _bool_attribute_ref = DenseBoolAttributeRef {
+        let _dense_bool_attribute_ref = DenseBoolAttributeRef {
             _prevent_external_instantiation: PhantomData,
         };
     }

--- a/src/mlir/ir/attribute/dense_bool.rs
+++ b/src/mlir/ir/attribute/dense_bool.rs
@@ -79,13 +79,40 @@ mod tests {
     use crate::Context;
 
     #[test]
-    fn test_dense_bool_attribute() {
+    fn get_elements_len() {
         let context = Context::new(None, false);
         let values = [true, false, true];
         let attr = DenseBoolAttributeRef::new(&context, &values);
         assert_eq!(attr.len(), 3);
+        assert!(!attr.is_empty());
+    }
+
+    #[test]
+    fn get_value() {
+        let context = Context::new(None, false);
+        let values = [true, false, true];
+        let attr = DenseBoolAttributeRef::new(&context, &values);
         assert!(attr.get(0));
         assert!(!attr.get(1));
         assert!(attr.get(2));
+    }
+
+    #[test]
+    fn get_value_out_of_bounds() {
+        let context = Context::new(None, false);
+        let values = [true, false, true];
+        let attr = DenseBoolAttributeRef::new(&context, &values);
+        assert!(std::panic::catch_unwind(|| {
+            attr.get(3);
+        })
+        .is_err());
+    }
+
+    #[test]
+    #[should_panic]
+    fn no_owned_dense_bool_attribute_ref() {
+        let _bool_attribute_ref = DenseBoolAttributeRef {
+            _prevent_external_instantiation: PhantomData,
+        };
     }
 }

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -1,18 +1,15 @@
-use std::{marker::PhantomData};
+use std::marker::PhantomData;
 
 use mlir_sys::{
-    MlirAttribute, mlirAttributeGetContext, mlirAttributeGetNull, mlirAttributeIsADenseElements,
+    mlirAttributeGetContext, mlirAttributeGetNull, mlirAttributeIsADenseElements,
     mlirDenseElementsAttrGetStringValue, mlirDenseElementsAttrStringGet,
-    mlirElementsAttrGetNumElements, MlirStringRef, mlirRankedTensorTypeGet
+    mlirElementsAttrGetNumElements, mlirRankedTensorTypeGet, MlirAttribute, MlirStringRef,
 };
 
 use crate::{
-    ContextRef,
-    ir::{
-        attribute::impl_attribute_variant,
-        IdentifierRef, NamedAttribute, TypeRef
-    }, StringRef,
-    support::binding::impl_unowned_mlir_value, UnownedMlirValue
+    ir::{attribute::impl_attribute_variant, IdentifierRef, NamedAttribute, TypeRef},
+    support::binding::impl_unowned_mlir_value,
+    ContextRef, StringRef, UnownedMlirValue,
 };
 
 /// [`StringBoolAttributeRef`] is a reference to an instance of the `mlir::DenseStringElementsAttr`, which
@@ -51,20 +48,21 @@ impl DenseStringAttributeRef {
         let shape: [i64; 1] = [values.len() as i64];
 
         let shaped_type = unsafe {
-            mlirRankedTensorTypeGet(1, shape.as_ptr(), {
-                TypeRef::parse(&context, string_type).unwrap().to_raw()
-            }, mlirAttributeGetNull())
+            mlirRankedTensorTypeGet(
+                1,
+                shape.as_ptr(),
+                { TypeRef::parse(&context, string_type).unwrap().to_raw() },
+                mlirAttributeGetNull(),
+            )
         };
 
-        unsafe{
-        Self::from_raw(
-            mlirDenseElementsAttrStringGet(
+        unsafe {
+            Self::from_raw(mlirDenseElementsAttrStringGet(
                 shaped_type,
                 values.len() as isize,
                 values.as_ptr() as *mut MlirStringRef,
             ))
         }
-
     }
 
     /// # Returns
@@ -110,8 +108,11 @@ impl DenseStringAttributeRef {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        ir::{DenseStringAttributeRef, LocationRef, OperationBuilder},
+        StringRef,
+    };
     use std::ffi::CString;
-    use crate::{ir::{DenseStringAttributeRef, LocationRef, OperationBuilder}, StringRef};
 
     #[test]
     fn test_compile_return_dense_string_attribute() {
@@ -121,7 +122,7 @@ mod tests {
         let strings = [
             CString::new("hello").unwrap(),
             CString::new("world").unwrap(),
-            CString::new("foo").unwrap()
+            CString::new("foo").unwrap(),
         ];
 
         let string_refs = strings
@@ -129,11 +130,12 @@ mod tests {
             .map(|s| StringRef::from_cstring(s))
             .collect::<Vec<StringRef>>();
 
-        let attr = DenseStringAttributeRef::new(&context, string_refs.as_slice(), "!dialect.string");
+        let attr =
+            DenseStringAttributeRef::new(&context, string_refs.as_slice(), "!dialect.string");
 
         let loc = LocationRef::new_unknown(&context);
         let op = OperationBuilder::new("dialect.op1", loc)
-            .add_attributes( &[attr.with_name("dense string")])
+            .add_attributes(&[attr.with_name("dense string")])
             .build()
             .unwrap();
 
@@ -141,14 +143,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_dense_string_attributes(){
+    fn test_get_dense_string_attributes() {
         let context = crate::Context::new(None, false);
         context.set_allow_unregistered_dialects(true);
 
         let strings = [
             CString::new("hello").unwrap(),
             CString::new("world").unwrap(),
-            CString::new("foo").unwrap()
+            CString::new("foo").unwrap(),
         ];
 
         let string_refs = strings
@@ -156,11 +158,12 @@ mod tests {
             .map(|s| StringRef::from_cstring(s))
             .collect::<Vec<StringRef>>();
 
-        let attr = DenseStringAttributeRef::new(&context, string_refs.as_slice(), "!dialect.string");
+        let attr =
+            DenseStringAttributeRef::new(&context, string_refs.as_slice(), "!dialect.string");
 
         let loc = LocationRef::new_unknown(&context);
         let op = OperationBuilder::new("dialect.op1", loc)
-            .add_attributes( &[attr.with_name("dense string")])
+            .add_attributes(&[attr.with_name("dense string")])
             .build()
             .unwrap();
 

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -51,7 +51,7 @@ impl DenseStringAttributeRef {
             mlirRankedTensorTypeGet(
                 1,
                 shape.as_ptr(),
-                { TypeRef::parse(&context, string_type).unwrap().to_raw() },
+                TypeRef::parse(&context, string_type).unwrap().to_raw(),
                 mlirAttributeGetNull(),
             )
         };

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -10,7 +10,7 @@ use crate::{
     ContextRef,
     ir::{
         attribute::impl_attribute_variant,
-        IdentifierRef, LocationRef, NamedAttribute, OperationBuilder, TypeRef
+        IdentifierRef, NamedAttribute, TypeRef
     }, StringRef,
     support::binding::impl_unowned_mlir_value, UnownedMlirValue
 };
@@ -166,7 +166,7 @@ mod tests {
 
         let attribute_ref = op.attribute("dense string").unwrap();
         let dense_attribute = DenseStringAttributeRef::try_from_attribute(attribute_ref).unwrap();
-        
+
         assert_eq!(dense_attribute.len(), 3);
         assert!(dense_attribute.get(0).eq(&string_refs[0]));
         assert!(dense_attribute.get(1).eq(&string_refs[1]));

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -12,7 +12,7 @@ use crate::{
     StringRef, UnownedMlirValue,
 };
 
-/// [`StringBoolAttributeRef`] is a reference to an instance of the `mlir::DenseStringElementsAttr`, which
+/// [`DenseStringAttributeRef`] is a reference to an instance of the `mlir::DenseStringElementsAttr`, which
 /// represents a constant array of strings in the MLIR IR.
 ///
 /// The following bindings into the MLIR C API are used/supported:

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -1,0 +1,97 @@
+use crate::{ContextRef, StringRef, UnownedMlirValue};
+
+use std::{marker::PhantomData};
+
+use crate::ir::TypeRef;
+use mlir_sys::{
+    mlirAttributeGetNull,
+    mlirDenseElementsAttrGetStringValue, mlirDenseElementsAttrStringGet,
+    mlirElementsAttrGetNumElements, mlirRankedTensorTypeGet, MlirAttribute,
+    MlirStringRef,
+};
+
+/// [`StringBoolAttributeRef`] is a reference to an instance of the `mlir::DenseStringElementsAttr`, which
+/// represents a constant array of strings in the MLIR IR.
+///
+/// The following bindings into the MLIR C API are used/supported:
+///
+/// The following bindings are not used/supported:
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct DenseStringAttributeRef {
+    _prevent_external_instantiation: PhantomData<()>,
+    raw: MlirAttribute,
+}
+
+impl DenseStringAttributeRef {
+    /// Constructs a new dense array of strings attribute with the provided values.
+    ///
+    /// # Arguments
+    /// * `context` - The context that should own the attribute.
+    /// * `values` - The strings to hold in the attribute.
+    /// * `string_type` - The string type to be parsed to an MlirType.
+    ///
+    /// # Returns
+    /// Returns a reference to a new [`DenseStringAttributeRef`] instance.
+    pub fn new<'a>(
+        context: &'a ContextRef,
+        values: &[StringRef],
+        string_type: &str,
+    ) -> DenseStringAttributeRef {
+        let shape: [i64; 1] = [values.len() as i64];
+
+        let shaped_type = unsafe {
+            mlirRankedTensorTypeGet(1, shape.as_ptr(), {
+                TypeRef::parse(context, string_type).unwrap().to_raw()
+            }, mlirAttributeGetNull())
+        };
+
+        let dense_elements_attr = unsafe {
+            mlirDenseElementsAttrStringGet(
+                shaped_type,
+                values.len() as isize,
+                values.as_ptr() as *mut MlirStringRef,
+            )
+        };
+
+        unsafe{Self::from_raw(dense_elements_attr) }
+    }
+
+    /// # Returns
+    /// Returns the length of the array.
+    pub fn len(&self) -> usize {
+        (unsafe { mlirElementsAttrGetNumElements(self.raw) }) as usize
+    }
+
+    /// # Returns
+    /// Returns whether the array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Gets the element at the provided index, verifying that the index is within bounds.
+    ///
+    /// # Arguments
+    /// * `index` - The index of the element to get.
+    ///
+    /// # Returns
+    /// Returns the string at the provided index.
+    pub fn get(&self, index: isize) -> StringRef {
+        assert!(index < self.len().try_into().unwrap());
+        unsafe {
+            let string_ref = mlirDenseElementsAttrGetStringValue(self.to_raw(), index);
+            StringRef::from_raw(string_ref)
+        }
+    }
+
+    pub unsafe fn from_raw(raw: MlirAttribute) -> Self {
+        Self {
+            _prevent_external_instantiation: Default::default(),
+            raw,
+        }
+    }
+
+    pub unsafe fn to_raw(&self) -> MlirAttribute {
+        self.raw
+    }
+}

--- a/src/mlir/ir/attribute/dense_string.rs
+++ b/src/mlir/ir/attribute/dense_string.rs
@@ -24,7 +24,6 @@ use crate::{
 #[derive(Debug)]
 pub struct DenseStringAttributeRef {
     _prevent_external_instantiation: PhantomData<()>,
-    raw: MlirAttribute,
 }
 
 impl_unowned_mlir_value!(no_refs, DenseStringAttributeRef, MlirAttribute);
@@ -101,6 +100,7 @@ impl DenseStringAttributeRef {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         ir::{DenseStringAttributeRef, Operation, TypeRef},
         Context,
@@ -164,5 +164,13 @@ mod tests {
         assert_eq!(attr_ref.get(0), "hello");
         assert_eq!(attr_ref.get(1), "world");
         assert_eq!(attr_ref.get(2), "foo");
+    }
+
+    #[test]
+    #[should_panic]
+    fn no_owned_dense_string_attribute_ref() {
+        let _dense_string_attribute_ref = DenseStringAttributeRef {
+            _prevent_external_instantiation: PhantomData,
+        };
     }
 }


### PR DESCRIPTION
This adds a DenseStringAttributeRef - note that this doesn't follow the pattern of us using DenseTypeArrayAttrs - this is a DenseStringElementsAttr. I've hidden those differences, it should work fundamentally the same as a DenseTypeArrayAttr. 